### PR TITLE
Added overridable methods for returing authz and token endpoints.

### DIFF
--- a/lib/LWP/Authen/OAuth2.pm
+++ b/lib/LWP/Authen/OAuth2.pm
@@ -719,8 +719,10 @@ Wellnhofer <wellnhofer@aevum.de> for Net::Google::Analytics::OAuth2 which
 was very enlightening while I was trying to figure out the details of how to
 connect to Google with OAuth2.
 
-Thanks to Thomas Klausner aka domm for reporting that client type specific
-parameters were not available when the client type was properly specified.
+Thanks to L<Thomas Klausner|https://github.com/domm> for reporting that client
+type specific parameters were not available when the client type was properly
+specified, and to L<Alexander Dutton|https://github.com/alexsdutton> for making
+C<ServiceProvider> work without requiring subclassing.
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LWP/Authen/OAuth2/ServiceProvider.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider.pm
@@ -81,7 +81,7 @@ sub authorization_url {
     my ($self, $oauth2, @rest) = @_;
     my $param
         = $self->collect_action_params("authorization", $oauth2, @rest);
-    my $uri = URI->new($self->{"authorization_endpoint"});
+    my $uri = URI->new($self->authorization_endpoint());
     $uri->query_form(%$param);
     return $uri->as_string;
 }
@@ -225,7 +225,7 @@ sub construct_tokens {
     }
     my $data = eval {decode_json($content)};
     my $parse_error = $@;
-    my $token_endpoint = $self->token_endpoint;
+    my $token_endpoint = $self->token_endpoint();
 
     # Can this have done wrong?  Let me list the ways...
     if ($parse_error) {
@@ -342,6 +342,17 @@ sub service_provider_class {
             croak("Service provider '$short_name' not found");
         }
     }
+}
+
+# DEFAULTS (can be overridden)
+sub authorization_endpoint {
+    my $self = shift;
+    return $self->{"authorization_endpoint"};
+}
+
+sub token_endpoint {
+    my $self = shift;
+    return $self->{"token_endpoint"};
 }
 
 # DEFAULTS (should be overridden)


### PR DESCRIPTION
Previously the base `ServiceProvider` class didn't provide a default `authorization_endpoint()` and `token_endpoint()` implementation, and so always required the use of a sub-class (and ignoring the values passed to the `OAuth2` constructor.
