### PR TITLE
Fixed copying required/optional params in collect_action_params.

### DIFF
--- a/lib/LWP/Authen/OAuth2/ServiceProvider.pm
+++ b/lib/LWP/Authen/OAuth2/ServiceProvider.pm
@@ -181,7 +181,7 @@ sub collect_action_params {
         my $result = {
             %$default,
             (
-                map $oauth2_args->{$_},
+                map {($_, $oauth2_args->{$_})}
                     @{ $self->{"$action\_required_params"} },
                     @{ $self->{"$action\_optional_params"} }
             ),


### PR DESCRIPTION
Default required and optional parameters weren't been copied properly when `$oauth2->is_strict` was false. This fixes the `map` call to generate pairs, which are flattened correctly into the returned hash.
